### PR TITLE
Add TechNottingham Attendance Requirement to Speaker Acquisition Secretary

### DIFF
--- a/src/sections/committee/officers/speaker-acquisition-secretary.tex
+++ b/src/sections/committee/officers/speaker-acquisition-secretary.tex
@@ -4,4 +4,5 @@
 	\item Work closely with organisers of flagship events \footnote{Large events with dedicated organisers, e.g. inspireWiT, HackSoc} to acquire speakers.
 	\item Ensure all guest speakers are confirmed 3 weeks prior to the event they'll be speaking and ensuring that the appropriate events forms are completed.
 	\item Shall prepare a written handover for their successor
+	\item Shall attend a minimum of 5 Tech Nottingham monthly events and is encouraged to attend as many hackathons as possible not for the competition but instead for networking purposes.
 \end{itemize}

--- a/src/sections/committee/officers/speaker-acquisition-secretary.tex
+++ b/src/sections/committee/officers/speaker-acquisition-secretary.tex
@@ -3,6 +3,6 @@
 	\item Be responsible for acquiring speakers for HackSoc speaker events
 	\item Work closely with organisers of flagship events \footnote{Large events with dedicated organisers, e.g. inspireWiT, HackSoc} to acquire speakers.
 	\item Ensure all guest speakers are confirmed 3 weeks prior to the event they'll be speaking and ensuring that the appropriate events forms are completed.
-	\item Shall prepare a written handover for their successor
-	\item Shall attend a minimum of 5 Tech Nottingham monthly events and is encouraged to attend as many hackathons as possible not for the competition but instead for networking purposes.
+	\item Shall prepare a written handover for their successor.
+	\item Support activities that encourage outreach in the technology community, such as maintaining relationships with Tech Nottingham by regularly attending meetups.
 \end{itemize}


### PR DESCRIPTION
Added event attendance requirements

# Constitutional Amendment Pull Request
## Voting result (Leave this section)

_Members present and voting:_ 21

### Tally
_For:_ 21/21
_Against:_ 0/21




## Summary of Changes (Complete this section)

### Sections Change
 - 1.11

### Detail of changes
Added an attendance req. for tech Nottingham events

## Justification of changes (Complete this section – Justify ammendment)
In order for a speaker acquisition sec to reach out to "good" speakers for lack of a better word, they need to network as much as possible and meet potential speakers in person as cold calling / cold emailing is quite ineffective.