### PR TITLE
Amend/2019 10 28/update numbering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,4 @@ TSWLatexianTemp*
 
 *.pdf
 *.aux
+*.synctex(busy)

--- a/constitution.cls
+++ b/constitution.cls
@@ -11,9 +11,6 @@
 \RequirePackage{catchfile}
 \RequirePackage{graphicx}
 
-% Temporary
-\setcounter{section}{1}
-
 \titleformat{\section}[hang]{\normalfont}
 {\thesection~~~}{.5em}{}[\quad]
 \titleformat{\section}[hang]{\fontsize{14}{17}\bfseries}{\noindent\thesection. }{1pt}{}[\quad]

--- a/src/core/aims-and-objectives.tex
+++ b/src/core/aims-and-objectives.tex
@@ -1,4 +1,4 @@
-\section*{Aims \& Objectives}
+\section{Aims \& Objectives}
 \begin{clause}
 The aims of the society are:
 	\begin{itemize}

--- a/src/core/society-name.tex
+++ b/src/core/society-name.tex
@@ -1,4 +1,4 @@
-\section*{Society Name: HackSoc}
+\section{Society Name: HackSoc}
 \begin{clause}
   The name of the society shall hereby be referred to as HackSoc, and shall be stated as such in all correspondence (e.g. room bookings).
 \end{clause}

--- a/src/core/union-policies.tex
+++ b/src/core/union-policies.tex
@@ -1,3 +1,4 @@
+\section{Superordinate Policies}
 \begin{clause}
 The Society shall abide by the Clubs and Societies Code of Practice and the Students' Union Equal Opportunities Policy.
 \end{clause}

--- a/src/sections/appointment/index.tex
+++ b/src/sections/appointment/index.tex
@@ -1,3 +1,3 @@
-\section*{Appointment}
+\section{Appointment}
 \input{src/sections/appointment/officers.tex}
 \input{src/sections/appointment/hacknotts-organisers.tex}

--- a/src/sections/authority/index.tex
+++ b/src/sections/authority/index.tex
@@ -1,2 +1,2 @@
-\section*{Authority}
+\section{Authority}
 \input{src/sections/authority/chain-of-authority.tex}

--- a/src/sections/committee/index.tex
+++ b/src/sections/committee/index.tex
@@ -1,4 +1,4 @@
-\section*{Committee}
+\section{Committee}
 \input{src/sections/committee/assertion.tex}
 \input{src/sections/committee/responsibilities.tex}
 \input{src/sections/committee/officers.tex}

--- a/src/sections/constitution/index.tex
+++ b/src/sections/constitution/index.tex
@@ -1,3 +1,3 @@
-\section*{Constitution}
+\section{Constitution}
 \input{src/sections/constitution/supermajority.tex}
 \input{src/sections/constitution/subordinate.tex}

--- a/src/sections/elections/index.tex
+++ b/src/sections/elections/index.tex
@@ -1,4 +1,4 @@
-\section*{Elections}
+\section{Elections}
 \input{src/sections/elections/secretaries-at-agm.tex}
 \input{src/sections/elections/su-regulations.tex}
 \input{src/sections/elections/stv.tex}

--- a/src/sections/finance/index.tex
+++ b/src/sections/finance/index.tex
@@ -1,3 +1,3 @@
-\section*{Finance}
+\section{Finance}
 \input{src/sections/finance/su-treasury.tex}
 \input{src/sections/finance/activities.tex}

--- a/src/sections/general-elections/index.tex
+++ b/src/sections/general-elections/index.tex
@@ -1,4 +1,4 @@
-\section*{General Elections}
+\section{General Elections}
 \input{src/sections/general-elections/agm-dates.tex}
 \input{src/sections/general-elections/egm.tex}
 \input{src/sections/general-elections/quorum.tex}

--- a/src/sections/membership/index.tex
+++ b/src/sections/membership/index.tex
@@ -1,4 +1,4 @@
-\section*{Membership}
+\section{Membership}
 \input{src/sections/membership/open-to-union-members.tex}
 \input{src/sections/membership/associate-membership.tex}
 \input{src/sections/membership/fee-at-agm.tex}

--- a/src/sections/sub-groups/index.tex
+++ b/src/sections/sub-groups/index.tex
@@ -1,2 +1,2 @@
-\section*{Sub Groups}
+\section{Sub Groups}
 \input{src/sections/sub-groups/cyber-sub-group.tex}


### PR DESCRIPTION
# Constitutional Amendment Pull Request
Update numbering to give sections their own numbers

## Summary of changes
 - Edited all section headers to show a number
 - Edited document class to remove set counter for section
 - Added superordinate policy section
 - Update section numbers for all clauses

## Justification of changes
The constitution has more than 30 clauses with clear sections, updating the numbering to indicate which section a clause in would make the constitution significantly more referencable

## Submission Checklist
 - [ ] Filled out amendment request form at [hacksoc.net/amend](https://hacksoc.net/amend)
 - [x] Set base branch to be the next general meeting and **NOT** master
 - [x] Head branch is named `amend/<YYYY-MM-DD of meeting>/<summary>`
